### PR TITLE
Fix for line 162

### DIFF
--- a/src/awzaw/antispampro/AntiSpamPro.php
+++ b/src/awzaw/antispampro/AntiSpamPro.php
@@ -159,7 +159,7 @@ class AntiSpamPro extends PluginBase implements CommandExecutor, Listener {
         if ($event->isCancelled() || $event->getPlayer()->isClosed()) return;
         if (($sender = $event->getPlayer())->hasPermission("asp.bypass")) return;
         $message = $event->getMessage();
-        if ($message{0} != "/") {
+        if ($message[0] != "/") {
             return;
         }
         if (isset($this->players[spl_object_hash($sender)]) && (time() - $this->players[spl_object_hash($sender)]["time"] <= intval($this->getConfig()->get("delay")))) {


### PR DESCRIPTION
18.04 11:49:45 [Server] INFO Deprecated: Array and string offset access syntax with curly braces is deprecated in phar:///plugins/AntiSpamPro_dev-30.phar/src/awzaw/antispampro/AntiSpamPro.php on line 162